### PR TITLE
[Feat]: 비밀번호 재발급 페이지 초안

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { Approval, ChangeGrade, MemberInfo } from '@components/admin';
 import { Temp1, Temp2, Temp3 } from '@components/Temp';
 import NotFound from '@components/common/error/NotFound';
 import Login from '@pages/Login/Login';
+import ResetPassword from '@pages/ResetPassword';
 
 function App() {
   const location = useLocation();
@@ -39,6 +40,7 @@ function App() {
         <Route path={ROUTE.SIGNUP} element={<SignUp />} />
         <Route path={ROUTE.ENTERINFO} element={<EnterInfo />} />
         <Route path={ROUTE.LOGIN} element={<Login />} />
+        <Route path={ROUTE.RESET_PASSWORD} element={<ResetPassword />} />
         <Route path={ROUTE.COMMUNITY.BASE} element={<Community />}>
           <Route path={ROUTE.COMMUNITY.LIST} element={<CommunityList />} />
           <Route path={ROUTE.COMMUNITY.WRITE} element={<CommunityWrite />} />

--- a/frontend/src/constants/route.ts
+++ b/frontend/src/constants/route.ts
@@ -11,6 +11,7 @@ const ROUTE = Object.freeze({
   },
   LOGIN: '/login',
   SIGNUP: '/signup',
+  RESET_PASSWORD: '/resetpassword',
   ENTERINFO: '/enterinfo',
   ADMIN: {
     BASE: '/admin',

--- a/frontend/src/pages/Login/Login.style.tsx
+++ b/frontend/src/pages/Login/Login.style.tsx
@@ -32,6 +32,7 @@ export const Content = styled.div`
 export const Label = styled.div`
   ${(props) => props.theme.typography.common.caption2};
   color: ${(props) => props.theme.colors.point1};
+  padding-left: 1.2rem;
 `;
 
 export const InputWrapper = styled.div`
@@ -68,9 +69,17 @@ export const ErrorMsg = styled.div`
 
 export const CompleteBtn = styled(Button)`
   margin-top: 8.4rem;
-  ${(props) => props.theme.typography.common.button1};
   color: ${(props) => props.theme.colors.white};
   border-radius: 1.2rem;
   height: 4.6rem;
   width: 12.6rem;
+  > span {
+    ${(props) => props.theme.typography.common.button1};
+  }
+`;
+
+export const PasswordIssue = styled.a`
+  color: ${(props) => props.theme.colors.point2};
+  ${(props) => props.theme.typography.common.caption1};
+  align-self: flex-end;
 `;

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -3,9 +3,13 @@ import { ConfigProvider } from 'antd';
 import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
 import theme from '@styles/theme';
 import useInput from '@hooks/useInput';
+import ROUTE from '@constants/route';
+import { useNavigate } from 'react-router-dom';
 import * as L from './Login.style';
 
 export default function Login() {
+  const navigate = useNavigate();
+
   const [id, setid] = useInput<string>('');
   const [pw, setPw] = useInput<string>('');
 
@@ -68,6 +72,7 @@ export default function Login() {
           </ConfigProvider>
           <L.ErrorMsg>{errorMsg2}</L.ErrorMsg>
         </L.InputWrapper>
+        <L.PasswordIssue onClick={() => navigate(ROUTE.RESET_PASSWORD)}>비밀번호 재발급</L.PasswordIssue>
         <ConfigProvider
           theme={{
             token: {

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ConfigProvider } from 'antd';
+import theme from '@styles/theme';
+import useInput from '@hooks/useInput';
+import * as R from './Login/Login.style';
+
+const Container = styled.div`
+  padding: 10rem 0;
+  min-height: 80vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+
+  ${(props) => props.theme.media.tablet`
+    padding: 20rem 0;
+  `};
+  ${(props) => props.theme.media.desktop`
+    padding: 20% 0;
+  `};
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4.4rem;
+  width: 32.8rem;
+`;
+
+export default function ResetPassword() {
+  const [email, setEmail] = useInput<string>('');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  const onClickBtn = () => {
+    const regex = /^([a-zA-Z0-9_.-]+)@([a-zA-Z0-9_.-]+)\.([a-zA-Z]{2,5})$/;
+    if (email.length === 0) setErrorMsg('이메일을 입력해주세요.');
+    else if (!regex.test(email)) setErrorMsg('이메일 형식이 올바르지 않습니다.');
+    else setErrorMsg('일치하는 회원정보가 없습니다.');
+  };
+
+  useEffect(() => {
+    if (email.length > 0) setErrorMsg('');
+  }, [email]);
+
+  return (
+    <Container>
+      <Content>
+        <R.InputWrapper>
+          <R.Label>이메일</R.Label>
+          <ConfigProvider
+            theme={{
+              token: {
+                colorBgContainer: theme.colors.grey001,
+                colorPrimary: theme.colors.point1,
+                lineWidth: 0,
+              },
+            }}
+          >
+            <R.CustomInput value={email} onChange={setEmail} />
+          </ConfigProvider>
+          <R.ErrorMsg>{errorMsg}</R.ErrorMsg>
+        </R.InputWrapper>
+        <ConfigProvider
+          theme={{
+            token: {
+              colorPrimary: theme.colors.point1,
+            },
+            components: {
+              Button: {
+                paddingInline: 0,
+                paddingBlock: 0,
+              },
+            },
+          }}
+        >
+          <R.CompleteBtn type="primary" onClick={onClickBtn}>
+            비밀번호 재발급
+          </R.CompleteBtn>
+        </ConfigProvider>
+      </Content>
+    </Container>
+  );
+}


### PR DESCRIPTION
# 비밀번호 재발급 페이지 초안

## 주요 변경 내용
- 비밀번호 재발급 페이지 초안 생성
- 로그인 페이지에 비밀번호 재발급 버튼 생성 & routing 설정
- input validation 처리

## 남은 작업 내용
- data 연결

## 참고용 시연 사진

![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/117376841/f2c480ab-1227-4b4d-aa57-52879edabd89)

![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/117376841/96b63d59-7d74-447b-b4da-7921c84a233f)

![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/117376841/fbe9c791-0c0a-4243-8218-8dfe070cd300)

![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/117376841/f2d03b8b-3ec6-4cd8-8c06-3a977cedf21a)


