### PR TITLE
[Fix]: 페이지네이션 문제, 인가에 따라 탭 다르게 보이는 기능

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,8 +37,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "craco --max_old_space_size=8192 start",
-    "build": "craco --max_old_space_size=8192 build",
+    "start": "craco start",
+    "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject"
   },
@@ -80,5 +80,5 @@
     "prettier": "^3.1.0",
     "typescript": "^5.3.2"
   },
-  "proxy": "http://hicc.co.kr:8080"
+  "proxy": "https://www.hicc.co.kr:8080"
 }

--- a/frontend/src/components/admin/MemberInfo.tsx
+++ b/frontend/src/components/admin/MemberInfo.tsx
@@ -30,6 +30,8 @@ export default function MemberInfo() {
     sort: currentOption?.value,
   });
 
+  console.log(curPageItem);
+
   const items: CollapseProps['items'] = curPageItem.map((user, index) => ({
     key: String(index + 1),
     label: <MemberItem userData={user} />,

--- a/frontend/src/components/admin/MemberInfo.tsx
+++ b/frontend/src/components/admin/MemberInfo.tsx
@@ -30,8 +30,6 @@ export default function MemberInfo() {
     sort: currentOption?.value,
   });
 
-  console.log(curPageItem);
-
   const items: CollapseProps['items'] = curPageItem.map((user, index) => ({
     key: String(index + 1),
     label: <MemberItem userData={user} />,

--- a/frontend/src/components/common/tab/Tab.tsx
+++ b/frontend/src/components/common/tab/Tab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import useTab from '@hooks/useTab';
+import useAuth from '@hooks/useAuth';
 import TabElement from './TabElement';
 import TabContainer from './Tab.style';
 
@@ -13,6 +14,7 @@ import TabContainer from './Tab.style';
 export interface TabUnit {
   key: string;
   label: string;
+  presidentAuthorization?: boolean;
 }
 
 interface TabProps {
@@ -22,12 +24,22 @@ interface TabProps {
 
 function Tab({ items, initKey }: TabProps) {
   const tabinfo = useTab({ initKey });
+  const { isPresident } = useAuth();
 
   return (
     <TabContainer>
-      {items.map((item, index) => (
-        <TabElement key={`tab-${item.key}-${index}`} item={item} {...tabinfo} />
-      ))}
+      {items.map((item, index) => {
+        // 인가가 필요없는 경우 모두 보여준다.
+        if (item.presidentAuthorization === undefined) {
+          return <TabElement key={`tab-${item.key}-${index}`} item={item} {...tabinfo} />;
+        }
+        // 인가가 필요한 경우 & 회장인 경우만 탭을 보여준다.
+        if (item.presidentAuthorization === true && isPresident) {
+          return <TabElement key={`tab-${item.key}-${index}`} item={item} {...tabinfo} />;
+        }
+        // 인가가 필요한 경우이나, 회장이 아니라면 탭을 보여주지 않는다.
+        return undefined;
+      })}
     </TabContainer>
   );
 }

--- a/frontend/src/components/community/common/WriteInfo.tsx
+++ b/frontend/src/components/community/common/WriteInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GRADE_ENUM, Grade } from '@components/type/CommonType';
-import isMoreThanExecutive from '@utils/isMoreThanExecutive';
 import time from '@utils/time';
+import Authorization from '@utils/Authorization';
 import * as W from './WriteInfo.style';
 
 interface WriteInfoProps {
@@ -11,11 +11,21 @@ interface WriteInfoProps {
 }
 
 function WriteInfo({ grade, name, date }: WriteInfoProps) {
+  const isLeaveUser = name === '';
+
+  const showName = () => {
+    if (isLeaveUser) {
+      return '(알 수 없음)';
+    }
+
+    return name;
+  };
+
   return (
     <W.Container>
       <W.WriterPart>
-        <W.GradeTag $show={isMoreThanExecutive(grade)}>{GRADE_ENUM[grade]}</W.GradeTag>
-        <W.Writer>{name}</W.Writer>
+        <W.GradeTag $show={Authorization.isMoreThanExecutive(grade) && !isLeaveUser}>{GRADE_ENUM[grade]}</W.GradeTag>
+        <W.Writer>{showName()}</W.Writer>
       </W.WriterPart>
       <W.WriteTime>{time(date)}</W.WriteTime>
     </W.Container>

--- a/frontend/src/components/home/RecentNews.tsx
+++ b/frontend/src/components/home/RecentNews.tsx
@@ -17,7 +17,6 @@ interface News {
 function RecentNews() {
   const newsResponse = useGetLatestNews(); // Retrieve the entire response object
   const NEWS_ITEMS = newsResponse.data;
-  console.log(NEWS_ITEMS);
 
   const navigate = useNavigate();
 

--- a/frontend/src/constants/keys.ts
+++ b/frontend/src/constants/keys.ts
@@ -23,6 +23,7 @@ export const STORE_KEYS = Object.freeze({
   NESTED_COMMENT: 'nestedComment',
   LOGIN: 'login',
   ADMIN: 'admin',
+  PRESIDENT: 'president',
 });
 
 export const COOKIE_KEYS = Object.freeze({

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,14 +1,17 @@
 import adminState from '@libs/store/adminState';
 import loginState from '@libs/store/login';
+import presidentStore from '@libs/store/presidentStore';
 import useGetUserInfo from '@query/get/useGetUserInfo';
-import isMoreThanExecutive from '@utils/isMoreThanExecutive';
+import Authorization from '@utils/Authorization';
 import { useEffect } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 
 function useAuth() {
   const [isLogin, setIsLogin] = useRecoilState(loginState);
   const [isAdmin, setIsAdmin] = useRecoilState(adminState);
+  const [isPresident, setIsPresident] = useRecoilState(presidentStore);
   const resetAdminState = useResetRecoilState(adminState);
+  const resetPresidentState = useResetRecoilState(presidentStore);
 
   const { userinfo, fetchUserInfo } = useGetUserInfo();
 
@@ -18,19 +21,22 @@ function useAuth() {
       fetchUserInfo();
     } else {
       resetAdminState();
+      resetPresidentState();
     }
-  }, [fetchUserInfo, isLogin, resetAdminState]);
+  }, [fetchUserInfo, isLogin, resetAdminState, resetPresidentState]);
 
-  // 회장, 운영진 이상일 경우 어드민 상태 활성화
+  // 회장, 운영진 이상일 경우 어드민 상태 활성화, 회장일 때는 회장상태 활성화
   useEffect(() => {
     if (userinfo !== undefined) {
-      setIsAdmin(isMoreThanExecutive(userinfo.grade));
+      setIsAdmin(Authorization.isMoreThanExecutive(userinfo.grade));
+      setIsPresident(Authorization.isPresident(userinfo.grade));
     }
-  }, [setIsAdmin, userinfo]);
+  }, [setIsAdmin, userinfo, setIsPresident]);
 
   return {
     isLogin,
     isAdmin,
+    isPresident,
     setIsLogin,
     setIsAdmin,
   };

--- a/frontend/src/libs/store/presidentStore.ts
+++ b/frontend/src/libs/store/presidentStore.ts
@@ -1,0 +1,9 @@
+import { STORE_KEYS } from '@constants/keys';
+import { atom } from 'recoil';
+
+const presidentStore = atom<boolean>({
+  key: STORE_KEYS.PRESIDENT,
+  default: false,
+});
+
+export default presidentStore;

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -16,6 +16,7 @@ const items: TabUnit[] = [
   {
     key: ROUTE.ADMIN.CHANGE,
     label: '등급 수정',
+    presidentAuthorization: true,
   },
 ];
 

--- a/frontend/src/query/get/useServerSidePagination.tsx
+++ b/frontend/src/query/get/useServerSidePagination.tsx
@@ -118,6 +118,8 @@ function useServerSidePagination<T>({
     queryClient.invalidateQueries({
       queryKey: [QUERY_KEYS.PAGEABLE, { uri }],
     });
+    setPage(0);
+    setIsLast(false);
     setData([]);
   }, [uri, size, sort, search, board, articleGrade, findBy, queryClient]);
 
@@ -133,13 +135,13 @@ function useServerSidePagination<T>({
       setData(cachingData.content);
     }
 
-    if (isInfinityScroll) {
+    if (isInfinityScroll && !isLast) {
       setData((prev) => [...prev, ...cachingData.content]);
       setIsLast(cachingData.last);
     }
 
     setDataLength(cachingData.totalElements);
-  }, [cachingData, isInfinityScroll]);
+  }, [cachingData, isInfinityScroll, isLast]);
 
   const onSetPage = (pageNum: number) => {
     setPage(pageNum - 1);

--- a/frontend/src/utils/Authorization.ts
+++ b/frontend/src/utils/Authorization.ts
@@ -1,0 +1,13 @@
+import { Grade } from '@components/type/CommonType';
+
+class Authorization {
+  static isMoreThanExecutive(grade: Grade) {
+    return grade === 'PRESIDENT' || grade === 'EXECUTIVE';
+  }
+
+  static isPresident(grade: Grade) {
+    return grade === 'PRESIDENT';
+  }
+}
+
+export default Authorization;

--- a/frontend/src/utils/isMoreThanExecutive.ts
+++ b/frontend/src/utils/isMoreThanExecutive.ts
@@ -1,7 +1,0 @@
-import { Grade } from '@components/type/CommonType';
-
-function isMoreThanExecutive(grade: Grade) {
-  return grade === 'PRESIDENT' || grade === 'EXECUTIVE';
-}
-
-export default isMoreThanExecutive;


### PR DESCRIPTION
# 페이지네이션 문제, 인가에 따라 탭 다르게 보이는 기능

## 주요 변경 내용
- 페이지네이션 (무한 스크롤)에서 검색, 정렬 기준이 변해도 잘 보이도록 설정
- 인가에 따라 다르게 보이도록 설정

## 참고 사항
- page/admin 페이지의 탭 아이템 내 presidentAuthorization: true를 적용하면 설정
- 하지만 회장이 아닐 때 url로 임의로 접속 시 막을 수는 없음 이는 백엔드가 인가 설정을 해줘야 함..

## 남은 작업 내용
-

## 참고용 시연 사진
<img width="960" alt="image" src="https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/81083461/51be44b6-1d45-4965-b8f2-a4ea8ebe97b0">

