### PR TITLE
[Design]:홈 화면 코딩 기호 사이즈 조정(브랜치를 실수로 mypage로 했습니다)

### DIFF
--- a/frontend/src/components/home/firstScreen/Matter.jsx
+++ b/frontend/src/components/home/firstScreen/Matter.jsx
@@ -36,6 +36,7 @@ export default function MatterDisplay(props) {
       },
     });
     const rate = props.width / 1920 || 1;
+    console.log(rate);
 
     // eslint-disable-next-line react/prop-types
     const floor = Bodies.rectangle(props.width / 2, props.height + 10, props.width, 20, {
@@ -43,7 +44,7 @@ export default function MatterDisplay(props) {
       render: { fillStyle: '#0A0A0A' },
     });
 
-    const HelloWorld = Bodies.rectangle(800 * rate, 0, 800 * rate, 144 * rate, {
+    const HelloWorld = Bodies.rectangle(800 * rate, 0, 608 * rate, 144 * rate, {
       chamfer: {
         radius: [72 * rate, 72 * rate],
       },
@@ -158,7 +159,7 @@ export default function MatterDisplay(props) {
       restitution: 0.1,
     });
 
-    const Component = Bodies.rectangle(1280 * rate, 200 * rate, 172 * rate, 116 * rate, {
+    const Component = Bodies.rectangle(1280 * rate, 200 * rate, 189 * rate, 116 * rate, {
       chamfer: {},
       render: {
         sprite: {

--- a/frontend/src/components/home/firstScreen/Matter.jsx
+++ b/frontend/src/components/home/firstScreen/Matter.jsx
@@ -36,51 +36,59 @@ export default function MatterDisplay(props) {
       },
     });
     const rate = props.width / 1920 || 1;
-    console.log(rate);
+    const SizeRate = Math.min(props.width / 1920 + 0.18, 1) || 1;
 
     // eslint-disable-next-line react/prop-types
     const floor = Bodies.rectangle(props.width / 2, props.height + 10, props.width, 20, {
       isStatic: true,
       render: { fillStyle: '#0A0A0A' },
     });
+    const leftWall = Bodies.rectangle(-40, props.height, 20, 200, {
+      isStatic: true,
+      render: { fillStyle: '#0A0A0A' },
+    });
+    const rightWall = Bodies.rectangle(props.width + 40, props.height, 20, 200, {
+      isStatic: true,
+      render: { fillStyle: '#0A0A0A' },
+    });
 
-    const HelloWorld = Bodies.rectangle(800 * rate, 0, 608 * rate, 144 * rate, {
+    const HelloWorld = Bodies.rectangle(800 * rate, 0, 608, 144, {
       chamfer: {
         radius: [72 * rate, 72 * rate],
       },
       render: {
         sprite: {
           texture: helloworld,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Include = Bodies.rectangle(1600 * rate, 200 * rate, 496 * rate, 144 * rate, {
+    const Include = Bodies.rectangle(1600 * rate, 200 * rate, 496, 144, {
       chamfer: {
         radius: [72 * rate, 72 * rate],
       },
       render: {
         sprite: {
           texture: include,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Blank = Bodies.rectangle(250 * rate, 200 * rate, 300 * rate, 144 * rate, {
+    const Blank = Bodies.rectangle(250 * rate, 200 * rate, 300, 144, {
       chamfer: {
         radius: [40 * rate, 40 * rate],
       },
       render: {
         sprite: {
           texture: blank,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
@@ -91,32 +99,32 @@ export default function MatterDisplay(props) {
       render: {
         sprite: {
           texture: and,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Bracket = Bodies.rectangle(1080 * rate, 200 * rate, 352 * rate, 108 * rate, {
+    const Bracket = Bodies.rectangle(1080 * rate, 200 * rate, 352, 108, {
       chamfer: {},
       render: {
         sprite: {
           texture: bracket,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const AndAnd = Bodies.circle(300 * rate, 100 * rate, 100 * rate, {
+    const AndAnd = Bodies.circle(300 * rate, 100, 100, {
       chamfer: {},
       render: {
         sprite: {
           texture: andand,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
@@ -145,60 +153,71 @@ export default function MatterDisplay(props) {
       { x: 40, y: 144 },
       { x: 0, y: 72 },
     ];
-    const Rect = createSvgBody(800 * rate, 200 * rate, rectVertices, rate, '#5B4EF5');
+    const Rect = createSvgBody(800 * rate, 200 * rate, rectVertices, SizeRate, '#5B4EF5');
 
-    const Semicolon = Bodies.rectangle(1280 * rate, 200 * rate, 24.8 * rate, 95 * rate, {
+    const Semicolon = Bodies.rectangle(1280 * rate, 200 * rate, 24.8, 95, {
       chamfer: {},
       render: {
         sprite: {
           texture: semicolon,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Component = Bodies.rectangle(1280 * rate, 200 * rate, 189 * rate, 116 * rate, {
+    const Component = Bodies.rectangle(1280 * rate, 200 * rate, 189, 116, {
       chamfer: {},
       render: {
         sprite: {
           texture: component,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Arrow = Bodies.rectangle(1280 * rate, 200 * rate, 184 * rate, 126 * rate, {
+    const Arrow = Bodies.rectangle(1280 * rate, 200 * rate, 184, 126, {
       chamfer: {},
       render: {
         sprite: {
           texture: arrow,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    const Wave = Bodies.rectangle(1480 * rate, 200 * rate, 300 * rate, 160 * rate, {
+    const Wave = Bodies.rectangle(1480 * rate, 200 * rate, 300, 160, {
       chamfer: {},
       render: {
         sprite: {
           texture: wave,
-          xScale: rate,
-          yScale: rate,
+          xScale: SizeRate,
+          yScale: SizeRate,
         },
       },
       restitution: 0.1,
     });
 
-    Matter.Body.scale(And, rate, rate);
+    Matter.Body.scale(HelloWorld, SizeRate, SizeRate);
+    Matter.Body.scale(Include, SizeRate, SizeRate);
+    Matter.Body.scale(Blank, SizeRate, SizeRate);
+    Matter.Body.scale(And, SizeRate, SizeRate);
+    Matter.Body.scale(Bracket, SizeRate, SizeRate);
+    Matter.Body.scale(AndAnd, SizeRate, SizeRate);
+    Matter.Body.scale(Semicolon, SizeRate, SizeRate);
+    Matter.Body.scale(Component, SizeRate, SizeRate);
+    Matter.Body.scale(Arrow, SizeRate, SizeRate);
+    Matter.Body.scale(Wave, SizeRate, SizeRate);
 
     World.add(engine.world, [
       floor,
+      leftWall,
+      rightWall,
       HelloWorld,
       Include,
       And,

--- a/frontend/src/components/mypage/style/MyComments.style.tsx
+++ b/frontend/src/components/mypage/style/MyComments.style.tsx
@@ -25,7 +25,6 @@ export const GroupContainer = styled.div`
   flex-direction: column;
   align-items: center;
   flex-shrink: 0;
-  height: auto;
   ${(props) => props.theme.media.mobile`
     margin-top: 1.2rem;
     width: 32.8rem;
@@ -139,20 +138,24 @@ export const ContentsContainer = styled.div`
   align-items: flex-start;
   ${(props) => props.theme.media.mobile`
     width: 32.8rem;
+    min-height: 65.3rem;
   `}
 
   ${(props) => props.theme.media.tablet`
     width: 53.4rem;
+    min-height: 81.4rem;
   `}
 
   ${(props) => props.theme.media.desktop`
     top: 6.4rem;
     width: 103.4rem;
+    min-height: 163.6rem;
   `}
 
   ${(props) => props.theme.media.wide`
     top: 6.4rem;
     width: 103.4rem;
+    min-height: 163.6rem;
   `}
 `;
 

--- a/frontend/src/components/mypage/style/MyWritings.style.tsx
+++ b/frontend/src/components/mypage/style/MyWritings.style.tsx
@@ -138,24 +138,24 @@ export const ContentsContainer = styled.div`
   align-items: flex-start;
   ${(props) => props.theme.media.mobile`
     width: 32.8rem;
-    height: 65.3rem;
+    min-height: 65.3rem;
   `}
 
   ${(props) => props.theme.media.tablet`
     width: 53.4rem;
-    height: 81.4rem;
+    min-height: 81.4rem;
   `}
 
   ${(props) => props.theme.media.desktop`
     top: 6.4rem;
     width: 103.4rem;
-    height: 163.6rem;
+    min-height: 163.6rem;
   `}
 
   ${(props) => props.theme.media.wide`
     top: 6.4rem;
     width: 103.4rem;
-    height: 163.6rem;
+    min-height: 163.6rem;
   `}
 `;
 


### PR DESCRIPTION
# 홈 화면 코딩 기호 사이즈 조정(브랜치를 실수로 mypage로 했습니다)

## 주요 변경 내용
- 홈 화면 코딩 기호 사이즈 조정
- 옆으로 완전히 떨어지지 않도록 벽 추가

## 참고 사항
- 실수로 mypage branch에서 작성했습니다.

## 남은 작업 내용
- 없음

## 참고용 시연 사진
![image](https://github.com/HICC-REBOOT/HICC-REBOOT-Frontend/assets/79552567/a36affd9-3d4c-4fa0-bed9-7f8531343dbf)

